### PR TITLE
Adding the courses taught in summer term 2025

### DIFF
--- a/content/classes/academic-writing-2025/index.md
+++ b/content/classes/academic-writing-2025/index.md
@@ -1,0 +1,20 @@
++++
+title = 'Academic Writing'
+subtitle = 'HHU, Summer 2025: [Course catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=264133)'
+summary = "The goal of this seminar is to gain research skills and to become familiar with the writing and research process. We will be dealing with the general steps of the research process, with conducting research using the tools and institutions available at our university, as well as with formal aspects of academic writing such as citations, formatting, structure of argumentation, and plagiarism. As academic conventions differ between institutes and departments, this course focuses on linguistic research in particular, and will provide the skills that are necessary for your term papers and BA dissertation."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+

--- a/content/classes/academic-writing-2025/main.md
+++ b/content/classes/academic-writing-2025/main.md
@@ -1,0 +1,23 @@
++++
+title = 'Academic Writing'
+subtitle = '[**Akhilesh Kakolu Ramarao**](https://slam.phil.hhu.de/authors/akhilesh/), Summer 2025, [Course Catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=264133)'
+summary = "The goal of this seminar is to gain research skills and to become familiar with the writing and research process. We will be dealing with the general steps of the research process, with conducting research using the tools and institutions available at our university, as well as with formal aspects of academic writing such as citations, formatting, structure of argumentation, and plagiarism. As academic conventions differ between institutes and departments, this course focuses on linguistic research in particular, and will provide the skills that are necessary for your term papers and BA dissertation."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+
+## Course Description
+
+The goal of this seminar is to gain research skills and to become familiar with the writing and research process. We will be dealing with the general steps of the research process, with conducting research using the tools and institutions available at our university, as well as with formal aspects of academic writing such as citations, formatting, structure of argumentation, and plagiarism. As academic conventions differ between institutes and departments, this course focuses on linguistic research in particular, and will provide the skills that are necessary for your term papers and BA dissertation.

--- a/content/classes/applied-phon-ASR-2025/index.md
+++ b/content/classes/applied-phon-ASR-2025/index.md
@@ -1,0 +1,20 @@
++++
+title = 'Applied Phonology: Evaluating Voice Assistants'
+subtitle = 'HHU, Summer 2025: [Course catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&publishid=263872&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung)'
+summary = "Have you ever been curious about why Voice Assistants (Siri, Amazon Echo and Google Assistant) sometimes struggle to understand your English accent? As linguists, we can play a crucial role in evaluating these sophisticated systems. In this class, you will assess these voice assistants by evaluating them against your own recorded speech. We will start by using the recording lab to record your voice and create a dataset. We will then use the voice assistants over this dataset. Once we know the possible errors from these systems, we will find the source of the errors using phonological analysis."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+

--- a/content/classes/applied-phon-ASR-2025/main.md
+++ b/content/classes/applied-phon-ASR-2025/main.md
@@ -1,0 +1,32 @@
++++
+title = 'Applied Phonology: Evaluating Voice Assistants'
+subtitle = '[**Akhilesh Kakolu Ramarao**](https://slam.phil.hhu.de/authors/akhilesh/), [**Erdin Mujezinovic**](https://slam.phil.hhu.de/authors/erdin/), Summer 2025, [Course Catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&publishid=263872&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung)'
+summary = "Have you ever been curious about why Voice Assistants (Siri, Amazon Echo and Google Assistant) sometimes struggle to understand your English accent? As linguists, we can play a crucial role in evaluating these sophisticated systems. In this class, you will assess these voice assistants by evaluating them against your own recorded speech. We will start by using the recording lab to record your voice and create a dataset. We will then use the voice assistants over this dataset. Once we know the possible errors from these systems, we will find the source of the errors using phonological analysis."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+
+## Course Description
+
+Have you ever been curious about why Voice Assistants (Siri, Amazon Echo and Google Assistant) sometimes struggle to understand your English accent? As linguists, we can play a crucial role in evaluating these sophisticated systems.
+
+In this class, you will assess these voice assistants by evaluating them against your own recorded speech. We will start by using the recording lab to record your voice and create a dataset. We will then use the voice assistants over this dataset. Once we know the possible errors from these systems, we will find the source of the errors using phonological analysis.
+
+Throughout the course, you will gain the knowledge in the following areas:
+
+- Techniques of making recordings in a laboratory setting
+- Dealing with audios
+- Evaluating voice assistants with your own voice
+- Finding the source of the error using phonological analysis

--- a/content/classes/colloquium-2025/index.md
+++ b/content/classes/colloquium-2025/index.md
@@ -1,0 +1,20 @@
++++
+title = 'Examens- und Forschungskolloquium'
+subtitle = 'HHU, Summer 2025: [Course catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=264132)'
+summary = "This colloquium is designed for students working on term papers, Bachelor's, Master's, or PhD theses who are seeking feedback and support for their ongoing research. We will meet in person every two weeks, with alternating weeks dedicated to group-based collaboration and peer exchange. In our first session, we will determine the presentation topics, which will form the structure of the colloquium program. Alongside project discussions, the in-person meetings will also cover key academic skills such as time management, hypothesis development, and critical reading."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+

--- a/content/classes/colloquium-2025/main.md
+++ b/content/classes/colloquium-2025/main.md
@@ -1,0 +1,23 @@
++++
+title = 'Examens- und Forschungskolloquium'
+subtitle = '[**Prof. Dr. Kevin Tang**](https://slam.phil.hhu.de/authors/kevin/), Summer 2025, [Course Catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=264132)'
+summary = "This colloquium is designed for students working on term papers, Bachelor's, Master's, or PhD theses who are seeking feedback and support for their ongoing research. We will meet in person every two weeks, with alternating weeks dedicated to group-based collaboration and peer exchange. In our first session, we will determine the presentation topics, which will form the structure of the colloquium program. Alongside project discussions, the in-person meetings will also cover key academic skills such as time management, hypothesis development, and critical reading."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+
+## Course Description
+
+This colloquium is designed for students working on term papers, Bachelor's, Master's, or PhD theses who are seeking feedback and support for their ongoing research. We will meet in person every two weeks, with alternating weeks dedicated to group-based collaboration and peer exchange. In our first session, we will determine the presentation topics, which will form the structure of the colloquium program. Alongside project discussions, the in-person meetings will also cover key academic skills such as time management, hypothesis development, and critical reading.

--- a/content/classes/ethics-biases-nlp-2025/index.md
+++ b/content/classes/ethics-biases-nlp-2025/index.md
@@ -1,0 +1,20 @@
++++
+title = 'Ethics, Bias and Natural Language Processing'
+subtitle = 'HHU, Summer 2025: [Course catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=264126)'
+summary = "Is technology really as innocent and as objective as they are said to be? As machine learning (ML) and Artificial Intelligence (AI) becomes more prominent in our life from speech and voice recognition by Alexa to automatic fake news warnings of social media posts, issues with social bias and fairness in language technology become more pertinent than ever before. Negative impacts that biased ML and AI could have for various social identities such as race, gender and culture. Through research papers, we will gain a better understanding of the the ethics, fairness, bias-related challenges in Natural Language Processing. Throughout the course, students will gain an overview of the various types of Natural Language Processing models (e.g., Automatic Speech Recognition, Language Model, hate speech detection) and its implications for bias, diversity, Inclusion, Environmental and human costs, privacy and governance."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+

--- a/content/classes/ethics-biases-nlp-2025/main.md
+++ b/content/classes/ethics-biases-nlp-2025/main.md
@@ -1,0 +1,39 @@
++++
+title = 'Ethics, Bias and Natural Language Processing'
+subtitle = '[**Prof. Dr. Kevin Tang**](https://slam.phil.hhu.de/authors/kevin/), Summer 2025, [Course Catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=264126)'
+summary = "Is technology really as innocent and as objective as they are said to be? As machine learning (ML) and Artificial Intelligence (AI) becomes more prominent in our life from speech and voice recognition by Alexa to automatic fake news warnings of social media posts, issues with social bias and fairness in language technology become more pertinent than ever before. Negative impacts that biased ML and AI could have for various social identities such as race, gender and culture. Through research papers, we will gain a better understanding of the the ethics, fairness, bias-related challenges in Natural Language Processing. Throughout the course, students will gain an overview of the various types of Natural Language Processing models (e.g., Automatic Speech Recognition, Language Model, hate speech detection) and its implications for bias, diversity, Inclusion, Environmental and human costs, privacy and governance."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+
+## Course Description
+
+Is technology really as innocent and as objective as they are said to be? As machine learning (ML) and Artificial Intelligence (AI) becomes more prominent in our life from speech and voice recognition by Alexa to automatic fake news warnings of social media posts, issues with social bias and fairness in language technology become more pertinent than ever before. Negative impacts that biased ML and AI could have for various social identities such as race, gender and culture.
+
+Through research papers, we will gain a better understanding of the the ethics, fairness, bias-related challenges in Natural Language Processing. Throughout the course, students will gain an overview of the various types of Natural Language Processing models (e.g., Automatic Speech Recognition, Language Model, hate speech detection) and its implications for bias, diversity, Inclusion, Environmental and human costs, privacy and governance. They will gain comprehensive insights into the following key areas:
+     
+1. Dangers and superpowers: e.g., ”On the Dangers of Stochastic Parrots: Can Language Models
+Be Too Big?” (Bender et al. 2021) https://dl.acm.org/doi/10.1145/3442188.3445922
+
+2. Bias: e.g., ”Language (Technology) is Power: A Critical Survey of “Bias” in NLP” (Blodgett et al. 2020) https://aclanthology.org/2020.acl-main.485/
+
+3. Diversity and Inclusion + Environmental and human costs: ”A Survey of Race, Racism, and Anti-Racism in NLP” (Field et al. 2021) https://aclanthology.org/2021.acl-long.149/
+
+4. Privacy + Governance and Participatory Approaches, e.g., ”Data Governance in the Age of Large-Scale Data-Driven Language Technology” (Jernite et al. 2022) https://dl.acm.org/doi/abs/10.1145/3531146.3534637
+
+In the course, we will sample from existing research papers. You will be asked to read, discuss and summarize your understanding of the papers, through
+i) short reflection posts (paragraph-size), ii) selected longer research summaries (one page) per theme, and iii) in-class discussions .
+
+The in-class discussions will be held in different formats, such as i) poster presentations, ii) group debates, iii) role-playing, iv) mind-map.

--- a/content/classes/python-for-linguists/index.md
+++ b/content/classes/python-for-linguists/index.md
@@ -1,0 +1,20 @@
++++
+title = 'Python for Linguists'
+subtitle = 'HHU, Summer 2025: [Course catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=262891)'
+summary = "This course provides an introduction to computer programming using Python, a high-level programming language widely used in both academic and industry contexts. Designed specifically for students in linguistics and related fields, the course integrates technical training with a group project: the design and implementation of a constructed language (conlang), with a particular emphasis on generating and analysing noncewords (e.g., wug words)."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+

--- a/content/classes/python-for-linguists/main.md
+++ b/content/classes/python-for-linguists/main.md
@@ -1,0 +1,31 @@
++++
+title = 'Python for Linguists'
+subtitle = '[**Prof. Dr. Kevin Tang**](https://slam.phil.hhu.de/authors/kevin/), Summer 2025, [Course Catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=262891)'
+summary = "This course provides an introduction to computer programming using Python, a high-level programming language widely used in both academic and industry contexts. Designed specifically for students in linguistics and related fields, the course integrates technical training with a group project: the design and implementation of a constructed language (conlang), with a particular emphasis on generating and analysing noncewords (e.g., wug words)."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+
+## Course Description
+
+This course provides an introduction to computer programming using Python, a high-level programming language widely used in both academic and industry contexts. Designed specifically for students in linguistics and related fields, the course integrates technical training with a group project: the design and implementation of a constructed language (conlang), with a particular emphasis on generating and analysing noncewords (e.g., wug words).
+
+Students will learn core programming concepts—such as variables, loops, conditionals, functions, and data structures—through hands-on exercises situated in linguistic contexts. The nonceword focus provides an entry point into phonotactic constraints, morphological productivity, and grammatical patterning, enabling students to use code to generate, evaluate, and experiment with novel linguistic forms.
+
+The course follows a flipped-classroom model: students independently work through instructional materials and coding exercises in preparation for sessions that prioritise clarification, peer discussion, and collaborative development of the conlang project.
+
+By the end of the course, students should (ideally):
+* be familiar with variables, data types, control structures, reading and writing files, functions, and basic data structures.
+* understand basic program design and be able to independently produce small programs that perform basic generic tasks as well as specific tasks addressing questions in linguistic research

--- a/content/classes/statistics-r-2025/index.md
+++ b/content/classes/statistics-r-2025/index.md
@@ -1,0 +1,20 @@
++++
+title = 'Quantitative Methods for Linguistic Data: An Introduction to Statistics using R'
+subtitle = 'HHU, Winter 2024: [Course catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=262878)'
+summary = "It is as necessary to be numerate as it is to be literate, but students in the field of humanities are often not as numerate as they are literate. They will need to evaluate evidence that are based on probability-based models or statistical results in many of the courses that they take in university, as they consider the efficacy of vaccination and the severity of the pandemic, as they begin to vote in local and national elections, as they search for employment on the job market after graduating, and so on. With an increasingly digital world filled with big data, a command of statistical reasoning is more important than ever. In this course, we will learn numeracy through linguistics, specifically through phonetics and phonology by learning to analyse the sounds of languages quantitatively."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+

--- a/content/classes/statistics-r-2025/main.md
+++ b/content/classes/statistics-r-2025/main.md
@@ -1,0 +1,25 @@
++++
+title = 'Quantitative Methods for Linguistic Data: An Introduction to Statistics using R'
+subtitle = '[**Prof. Dr. Kevin Tang**](https://slam.phil.hhu.de/authors/kevin/), Summer 2025, [Course Catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=262878)'
+summary = "It is as necessary to be numerate as it is to be literate, but students in the field of humanities are often not as numerate as they are literate. They will need to evaluate evidence that are based on probability-based models or statistical results in many of the courses that they take in university, as they consider the efficacy of vaccination and the severity of the pandemic, as they begin to vote in local and national elections, as they search for employment on the job market after graduating, and so on. With an increasingly digital world filled with big data, a command of statistical reasoning is more important than ever. In this course, we will learn numeracy through linguistics, specifically through phonetics and phonology by learning to analyse the sounds of languages quantitatively."
+
+type = "widget_page"
+date = "2025-04-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+
+## Course Description
+
+It is as necessary to be numerate as it is to be literate, but students in the field of humanities are often not as numerate as they are literate. They will need to evaluate evidence that are based on probability-based models or statistical results in many of the courses that they take in university, as they consider the efficacy of vaccination and the severity of the pandemic, as they begin to vote in local and national elections, as they search for employment on the job market after graduating, and so on. With an increasingly digital world filled with big data, a command of statistical reasoning is more important than ever. In this course, we will learn numeracy through linguistics, specifically through phonetics and phonology by learning to analyse the sounds of languages quantitatively.
+
+How do we analyse the sounds of languages quantitatively? This course, Analysing the sounds of languages, covers the basics of quantitative methods using real data taken from the field of phonetics and phonology. We will provide a gentle introduction to the statistical program R (www.r-project.org) -- a program that is used by data scientists in the tech. industry and academic researchers. The course will consist of a combination of lectures, and plenty of hands-on exercises. We introduce research questions, such as ”Do Southerners in the US really talk more slowly?” or ”Why do we expect scholarly words to be longer than familiar words?” as a framework for introducing the numerical concepts required to answer research questions such as these. In this course, statistical methods are introduced with a research question and a solid understanding of the data, which is why we use real data and questions that are relevant to anyone who commands a spoken language. A good amount of space is also devoted to illustrating how to formulate and answer a research question, and hypothesis development and testing.

--- a/content/classes/vocal-alchemy-signal-processing/index.md
+++ b/content/classes/vocal-alchemy-signal-processing/index.md
@@ -1,0 +1,20 @@
++++
+title = 'Vocal Alchemy: Shaping Voices with Signal Processing'
+subtitle = 'HHU, Summer 2025: [Course catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=262899)'
+summary = "Brain waves, speech, and music are all phenomena that can be encoded in digital signals. On the most basic level, a digital signal is a numerical representation of a stream of data over time. Signal processing can also include multidimensional data arrays, such as videos or fMRIs (functional magnetic resonance imaging). The real power of digital signals is that they allow for flexible manipulation of these data in order to change the output (voice changing, audio processing/effects) or analyze the signal (spectral analysis, measuring loudness or noisiness, segmenting into distinct elements). Thanks to widely available computer and audio hardware combined with various software packages, it is possible to work with these techniques in real-time systems, which enable direct feedback for the user of the system. After establishing some basics of how these techniques are implemented, we will be focusing on building or reengineering our own practical systems used in medical diagnosis or linguistics, with the goal of presenting these systems as working demonstrations or interactive installations connected with an end of semester poster presentation. While we will cover theoretical concepts, this will be a hands-on course, where we will work to develop projects."
+
+type = "widget_page"
+date = "2025-05-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+

--- a/content/classes/vocal-alchemy-signal-processing/main.md
+++ b/content/classes/vocal-alchemy-signal-processing/main.md
@@ -1,0 +1,40 @@
++++
+title = 'Vocal Alchemy: Shaping Voices with Signal Processing'
+subtitle = '[**Prof. Dr. Kevin Tang**](https://slam.phil.hhu.de/authors/kevin/), **Dr. Esther Florin**,  **Dr. Carter Williams**, Summer 2025, [Course Catalog](https://lsf.hhu.de/qisserver/servlet/de.his.servlet.RequestDispatcherServlet?state=verpublish&status=init&vmfile=no&moduleCall=webInfo&publishConfFile=webInfo&publishSubDir=veranstaltung&veranstaltung.veranstid=262899)'
+summary = "Brain waves, speech, and music are all phenomena that can be encoded in digital signals. On the most basic level, a digital signal is a numerical representation of a stream of data over time. Signal processing can also include multidimensional data arrays, such as videos or fMRIs (functional magnetic resonance imaging). The real power of digital signals is that they allow for flexible manipulation of these data in order to change the output (voice changing, audio processing/effects) or analyze the signal (spectral analysis, measuring loudness or noisiness, segmenting into distinct elements). Thanks to widely available computer and audio hardware combined with various software packages, it is possible to work with these techniques in real-time systems, which enable direct feedback for the user of the system. After establishing some basics of how these techniques are implemented, we will be focusing on building or reengineering our own practical systems used in medical diagnosis or linguistics, with the goal of presenting these systems as working demonstrations or interactive installations connected with an end of semester poster presentation. While we will cover theoretical concepts, this will be a hands-on course, where we will work to develop projects."
+
+type = "widget_page"
+date = "2025-05-30T00:00:00Z"
+featured = true
+draft = false
+active = true
+show_date = false
+share = false
+profile = false
+
+[design.spacing]
+  # Customize the section spacing. Order is top, right, bottom, left.
+  # padding = ["10px", "0px", "10px", "0"]
+
++++
+
+## Course Description
+
+Brain waves, speech, and music are all phenomena that can be encoded in digital signals. On the most basic level, a digital signal is a numerical representation of a stream of data over time. Signal processing can also include multidimensional data arrays, such as videos or fMRIs (functional magnetic resonance imaging). The real power of digital signals is that they allow for flexible manipulation of these data in order to change the output (voice changing, audio processing/effects) or analyze the signal (spectral analysis, measuring loudness or noisiness, segmenting into distinct elements). Thanks to widely available computer and audio hardware combined with various software packages, it is possible to work with these techniques in real-time systems, which enable direct feedback for the user of the system. After establishing some basics of how these techniques are implemented, we will be focusing on building or reengineering our own practical systems used in medical diagnosis or linguistics, with the goal of presenting these systems as working demonstrations or interactive installations connected with an end of semester poster presentation. While we will cover theoretical concepts, this will be a hands-on course, where we will work to develop projects.
+
+We will be using a range of software programs to implement our projects, but importantly students do not need a background in programming, math, or physics to successfully complete projects. We will take advantage of visual data flow languages that do not require a detailed knowledge of computer coding, but which still allow for us to flexibly manipulate many variables of the signal processing chain.
+
+Taught by a team of three instructors from the areas of linguistics (Professor Dr. Kevin Tang), medicine (Professor Dr. Esther Florin), and music (Dr. Carter Williams), this course will embrace an interdisciplinary approach to digital signal processing that will allow student to explore applications in medicine, linguistic, and creative fields.
+
+**Learning outcomes:**
+
+Students will be able to:
+
+- Explain and implement basic concepts of digital signal processing
+- Articulate and apply basic concepts of brain processes (language, and multiple modal input)
+- Analyze research questions from a multidisciplinary perspective
+
+Students will acquire the following practical skills:
+
+- Technical skills: employ a range of signal processing tools (both software and hardware)
+- Soft skills: project management, problem solving, translation of a problem into practical requirements 


### PR DESCRIPTION
This PR adds the base content files for all courses taught in the summer term 2025. Each course includes an `index.md` for the entry in the course overview and a `main.md` for the detailed course pages. The newly created course directories are:

* `academic-writing-2025`: *Academic Writing*
* `applied-phon-ASR-2025`: *Applied Phonology: Evaluating Voice Assistants*
* `ethics-biases-nlp-2025`: *Ethics, Bias and Natural Language Processing*
* `python-for-linguists`: *Python for Linguists*
* `statistics-r-2025`: *Quantitative Methods for Linguistic Data: An Introduction to Statistics using R*
* `vocal-alchemy-signal-processing`: *Vocal Alchemy: Shaping Voices with Signal Processing*
* `colloquium-2025`: *Examens- und Forschungskolloquium*